### PR TITLE
BI-2377: Update download link for icu

### DIFF
--- a/test/bin/build-icu.sh
+++ b/test/bin/build-icu.sh
@@ -27,7 +27,7 @@ fail_on_error() {
 
         echo 'downloading icu...'
         cd "$ICU_DIR"
-        curl 'http://download.icu-project.org/files/icu4c/62.1/icu4c-62_1-src.tgz' --output "$icu_archive"
+        curl 'https://sourceforge.net/projects/icu/files/ICU4C/62.1/icu4c-62_1-src.tgz/download' --output "$icu_archive"
 
         echo 'extracting icu...'
         if [ "Windows_NT" = "$OS" ]; then


### PR DESCRIPTION
For now, this PR just changes the source forge download link for icu. The BUILD ticket to give me permissions to upload the dependency to Artifactory is still open--not sure the timeline on that.