### PR TITLE
DEVPROD-13301: template authenticode key name

### DIFF
--- a/.evg.yml
+++ b/.evg.yml
@@ -320,7 +320,7 @@ functions:
             --rm \
             -v $(pwd):$(pwd) -w $(pwd) \
             ${garasign_jsign_image} \
-            /bin/bash -c "jsign -a mongo-authenticode-2021 --replace --tsaurl http://timestamp.digicert.com -d SHA-256 release.msi"
+            /bin/bash -c "jsign -a ${authenticode_key_name} --replace --tsaurl http://timestamp.digicert.com -d SHA-256 release.msi"
 
   "start mongo-orchestration":
     - command: shell.exec


### PR DESCRIPTION
This commit templates our authenticode key name in preparation for the authenticode 2021 deprecation. The variable will be added to our Evergreen project as mongo-authenticode-2021, and later updated to 2024 when that certificate is ready.